### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/transform_binary_payload/template.yaml
+++ b/transform_binary_payload/template.yaml
@@ -96,7 +96,7 @@ Resources:
         - python3.6
         - nodejs14.x
         - nodejs12.x
-        - nodejs10.x
+        - nodejs14.x
       RetentionPolicy: Retain
 
   ############################################################################################


### PR DESCRIPTION
CloudFormation templates in aws-iot-core-lorawan have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.