### PR TITLE
Dragino updates

### DIFF
--- a/transform_binary_payload/README.md
+++ b/transform_binary_payload/README.md
@@ -67,6 +67,14 @@ Example binary decoders for the following devices are included in this sample:
 | Dragino      | LSE01                             | dragino_lse01      | x        |         |
 | Dragino      | LBT1                              | dragino_lbt1       | x        |         |
 | Dragino      | LDS01                             | dragino_lds01      | x        |         |
+| Dragino      | LAQ4                              | dragino_laq4       | x        |         |
+| Dragino      | LLMS01                            | dragino_llms01     | x        |         |
+| Dragino      | LSPH01                            | dragino_lsph01     |          | x       |
+| Dragino      | LDDS20                            | dragino_ldds20     |          | x       |
+| Dragino      | LWL02                             | dragino_lwl02      |          | x       |
+| Dragino      | LSN50                             | dragino_lsn50      | x        |         |
+| Dragino      | LSN50v2                           | dragino_lsn50v2    | x        |         |
+| Dragino      | LSN50v2-D23                       | dragino_lsn50v2d23 |          | x       |
 | Elsys        | all                               | elsys              | x        |         |
 | Globalsat    | LT-100                            | globalsat_lt100    | x        |         |
 | NAS          | Pulse Reader UM3080               | nas_um3080         | x        |         |
@@ -316,6 +324,14 @@ Please perform the following steps to deploy a sample application:
       | Dragino      | LSE01                             | dragino_lse01      | x        |         |
       | Dragino      | LBT1                              | dragino_lbt1       | x        |         |
       | Dragino      | LDS01                             | dragino_lds01      | x        |         |
+      | Dragino      | LAQ4                              | dragino_laq4       | x        |         |
+      | Dragino      | LLMS01                            | dragino_llms01     | x        |         |
+      | Dragino      | LSPH01                            | dragino_lsph01     |          | x       |
+      | Dragino      | LDDS20                            | dragino_ldds20     |          | x       |
+      | Dragino      | LWL02                             | dragino_lwl02      |          | x       |
+      | Dragino      | LSN50                             | dragino_lsn50      | x        |         |
+      | Dragino      | LSN50v2                           | dragino_lsn50v2    | x        |         |
+      | Dragino      | LSN50v2-D23                       | dragino_lsn50v2d23 |          | x       |
       | Elsys        | all                               | elsys              | x        |         |
       | Globalsat    | LT-100                            | globalsat_lt100    | x        |         |
       | NAS          | Pulse Reader UM3080               | nas_um3080         | x        |         |

--- a/transform_binary_payload/README.md
+++ b/transform_binary_payload/README.md
@@ -354,6 +354,17 @@ Please perform the following steps to deploy a sample application:
     | Dragino      | LSE01                              | AuHtlACmawQPVGM=                                                  |
     | Dragino      | LGT92                              | DSEAAAEVCMUGpAA=                                                  |
     | Dragino      | LBT1                               | DxwAAAIDQUJCQ0NEREVFRkYwMjcxMjFGNkFDMy0wNTk=                      |
+	  | Dragino      | LHT65                              | y6QHxgG4AQhmf/8=                                                  |
+	  | Dragino      | LSE01                              | AuHtlACmawQPVGM=                                                  |
+	  | Dragino      | LGT92                              | DSEAAAEVCMUGpAA=                                                  |
+	  | Dragino      | LAQ4                               | C0UEAAcBkAEFAZc=                                                  |
+	  | Dragino      | LLMS01                             | C0UBBQAVAQUAAQ==                                                  |
+	  | Dragino      | LSPH01                             | C0UBBQK3AQUAAQ==                                                  |
+	  | Dragino      | LDDS20                             | DRYKbwA=                                                          |
+	  | Dragino      | LWL02                              | S+ICAAAIAAAB                                                      |
+	  | Dragino      | LSN50v2-D23                        | DO8BVQDqAf////8=                                                  |
+	  | Dragino      | LSN50v2-S31                        | DPcAAAEJAAEMAZc=                                                  |
+	  | Dragino      | LBT1                               | DxwAAAIDQUJCQ0NEREVFRkYwMjcxMjFGNkFDMy0wNTk=                      |
     | Browan       | Tabs Object Locator                | Ae48SPbhAgRupmA=                                                  |
     | Browan       | Tabs Temperature & Humidity Sensor | CAs1Mv////8=                                                      |
     | Elsys        | all                                | MDEwMEUyMDIyOTA0MDAyNzA1MDYwNjAzMDgwNzBENjIxOTAwRTIxOTAwQTM=      |

--- a/transform_binary_payload/src-payload-decoders/node/dragino_ldds20.js
+++ b/transform_binary_payload/src-payload-decoders/node/dragino_ldds20.js
@@ -1,0 +1,29 @@
+function decodeUplink(input) {
+    bytes = input.bytes
+    port = input.fPort
+        // Decode an uplink message from a buffer
+        // (array) of bytes to an object of fields.
+        var value=(bytes[0]<<8 | bytes[1]) & 0x3FFF;
+        var batV=value/1000;//Battery,units:V
+         
+        value=bytes[2]<<8 | bytes[3];
+        var distance=(value);//distance,units:mm
+      
+        var i_flag = bytes[4]; 
+        
+        value=bytes[5]<<8 | bytes[6];
+        if(bytes[5] & 0x80)
+        {value |= 0xFFFF0000;}
+        var temp_DS18B20=(value/10).toFixed(2);//DS18B20,temperature  
+        
+        var s_flag = bytes[7];	
+        return {
+            data: {
+             Bat:batV,
+             Distance:distance,
+             Interrupt_flag:i_flag,
+             TempC_DS18B20:temp_DS18B20,
+             Sensor_flag:s_flag,
+            }
+        };
+}

--- a/transform_binary_payload/src-payload-decoders/node/dragino_ldds20.js
+++ b/transform_binary_payload/src-payload-decoders/node/dragino_ldds20.js
@@ -1,3 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 function decodeUplink(input) {
     bytes = input.bytes
     port = input.fPort

--- a/transform_binary_payload/src-payload-decoders/node/dragino_lsn50v2d23.js
+++ b/transform_binary_payload/src-payload-decoders/node/dragino_lsn50v2d23.js
@@ -1,0 +1,92 @@
+function decodeUplink(input) {
+    bytes = input.bytes
+    port = input.fPort
+    var mode=(bytes[6] & 0x7C)>>2;
+    var decode = {};
+    if((mode!=2)&&(mode!=31))
+        {
+        decode.BatV=(bytes[0]<<8 | bytes[1])/1000;
+        decode.TempC1= parseFloat(((bytes[2]<<24>>16 | bytes[3])/10).toFixed(2));
+        decode.ADC_CH0V=(bytes[4]<<8 | bytes[5])/1000;
+        decode.Digital_IStatus=(bytes[6] & 0x02)? "H":"L";
+        if(mode!=6)
+            {
+                decode.EXTI_Trigger=(bytes[6] & 0x01)? "TRUE":"FALSE";
+            decode.Door_status=(bytes[6] & 0x80)? "CLOSE":"OPEN";
+            }
+    }
+    if(mode=='0')
+        {
+        decode.Work_mode="IIC";
+        if((bytes[9]<<8 | bytes[10])===0)
+        {
+            decode.Illum=(bytes[7]<<24>>16 | bytes[8]);
+        }
+        else
+        {
+        decode.TempC_SHT=parseFloat(((bytes[7]<<24>>16 | bytes[8])/10).toFixed(2));
+        decode.Hum_SHT=parseFloat(((bytes[9]<<8 | bytes[10])/10).toFixed(1));
+        }
+    }
+    else if(mode=='1')
+        {
+        decode.Work_mode=" Distance";
+        decode.Distance_cm=parseFloat(((bytes[7]<<8 | bytes[8])/10) .toFixed(1));
+        if((bytes[9]<<8 | bytes[10])!=65535)
+        {
+            decode.Distance_signal_strength=parseFloat((bytes[9]<<8 | bytes[10]) .toFixed(0));
+        }
+    }
+    else if(mode=='2')
+        {
+        decode.Work_mode=" 3ADC";
+        decode.BatV=bytes[11]/10;
+        decode.ADC_CH0V=(bytes[0]<<8 | bytes[1])/1000;
+        decode.ADC_CH1V=(bytes[2]<<8 | bytes[3])/1000;
+        decode.ADC_CH4V=(bytes[4]<<8 | bytes[5])/1000;
+        decode.Digital_IStatus=(bytes[6] & 0x02)? "H":"L";
+        decode.EXTI_Trigger=(bytes[6] & 0x01)? "TRUE":"FALSE";
+        decode.Door_status=(bytes[6] & 0x80)? "CLOSE":"OPEN";
+        if((bytes[9]<<8 | bytes[10])===0)
+        {
+            decode.Illum=(bytes[7]<<24>>16 | bytes[8]);
+        }
+        else
+        {
+        decode.TempC_SHT=parseFloat(((bytes[7]<<24>>16 | bytes[8])/10).toFixed(2));
+        decode.Hum_SHT=parseFloat(((bytes[9]<<8 | bytes[10])/10) .toFixed(1));
+        }
+    }
+    else if(mode=='3')
+        {
+        decode.Work_mode="3DS18B20";
+        decode.TempC2=parseFloat(((bytes[7]<<24>>16 | bytes[8])/10).toFixed(2));
+        decode.TempC3=parseFloat(((bytes[9]<<24>>16 | bytes[10])/10) .toFixed(1));
+    }
+    else if(mode=='4')
+        {
+        decode.Work_mode="Weight";
+        decode.Weight=(bytes[7]<<24>>16 | bytes[8]);
+    }
+    else if(mode=='5')
+        {
+        decode.Work_mode="Count";
+        decode.Count=(bytes[7]<<24 | bytes[8]<<16 | bytes[9]<<8 | bytes[10]);
+    }
+    else if(mode=='31')
+        {
+        decode.Work_mode="ALARM";
+        decode.BatV=(bytes[0]<<8 | bytes[1])/1000;
+        decode.TempC1= parseFloat(((bytes[2]<<24>>16 | bytes[3])/10).toFixed(2));
+        decode.TempC1MIN= bytes[4]<<24>>24;
+        decode.TempC1MAX= bytes[5]<<24>>24; 
+        decode.SHTEMPMIN= bytes[7]<<24>>24;
+        decode.SHTEMPMAX= bytes[8]<<24>>24;   
+        decode.SHTHUMMIN= bytes[9];
+        decode.SHTHUMMAX= bytes[10];    
+    }
+    if((bytes.length==11)||(bytes.length==12))
+        {
+        return decode;
+    }
+}

--- a/transform_binary_payload/src-payload-decoders/node/dragino_lsn50v2d23.js
+++ b/transform_binary_payload/src-payload-decoders/node/dragino_lsn50v2d23.js
@@ -1,3 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 function decodeUplink(input) {
     bytes = input.bytes
     port = input.fPort

--- a/transform_binary_payload/src-payload-decoders/node/dragino_lsph01.js
+++ b/transform_binary_payload/src-payload-decoders/node/dragino_lsph01.js
@@ -1,0 +1,36 @@
+function decodeUplink(input) {
+    bytes = input.bytes
+    port = input.fPort
+		// Decode an uplink message from a buffer
+		// (array) of bytes to an object of fields.
+		var value=(bytes[0]<<8 | bytes[1]) & 0x3FFF;
+		var batV=value/1000;//Battery,units:V
+
+		value=bytes[2]<<8 | bytes[3];
+		if(bytes[2] & 0x80)
+		{value |= 0xFFFF0000;}
+		var temp_DS18B20=(value/10).toFixed(2);//DS18B20,temperature
+
+		value=bytes[4]<<8 | bytes[5];
+		var PH1=(value/100).toFixed(2);
+
+		value=bytes[6]<<8 | bytes[7];
+		var temp=0;
+		if((value & 0x8000)>>15 === 0)
+			temp=(value/10).toFixed(2);//temp_SOIL,temperature
+		else if((value & 0x8000)>>15 === 1)
+			temp=((value-0xFFFF)/10).toFixed(2);
+
+		var i_flag = bytes[8];
+		var mes_type = bytes[10];
+    return {
+		data: {
+			Bat:batV,
+			TempC_DS18B20:temp_DS18B20,
+			PH1_SOIL:PH1,
+			TEMP_SOIL:temp,
+			Interrupt_flag:i_flag,
+			Message_type:mes_type
+		}
+    };
+}

--- a/transform_binary_payload/src-payload-decoders/node/dragino_lsph01.js
+++ b/transform_binary_payload/src-payload-decoders/node/dragino_lsph01.js
@@ -1,3 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 function decodeUplink(input) {
     bytes = input.bytes
     port = input.fPort

--- a/transform_binary_payload/src-payload-decoders/node/dragino_lwl02.js
+++ b/transform_binary_payload/src-payload-decoders/node/dragino_lwl02.js
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+function decodeUplink(input) {
+    bytes = input.bytes
+    port = input.fPort
+  // Decode an uplink message from a buffer
+  // (array) of bytes to an object of fields.
+  var value=(bytes[0]<<8 | bytes[1])&0x3FFF;
+  var bat=value/1000;//Battery,units:V
+  
+  var door_open_status=bytes[0]&0x80?1:0;//1:open,0:close
+  var water_leak_status=bytes[0]&0x40?1:0;
+  
+  var mod=bytes[2];
+  var alarm=bytes[9]&0x01;
+  
+  if(mod==1){
+    var open_times=bytes[3]<<16 | bytes[4]<<8 | bytes[5];
+    var open_duration=bytes[6]<<16 | bytes[7]<<8 | bytes[8];//units:min
+    if(bytes.length==10 &&  0x07>bytes[0]< 0x0f)
+    return {
+      data: {
+        BAT_V:bat,
+        MOD:mod,
+        DOOR_OPEN_STATUS:door_open_status,
+        DOOR_OPEN_TIMES:open_times,
+        LAST_DOOR_OPEN_DURATION:open_duration,
+        ALARM:alarm
+      }
+    };
+  }
+  else if(mod==2)
+  {
+    var leak_times=bytes[3]<<16 | bytes[4]<<8 | bytes[5];
+    var leak_duration=bytes[6]<<16 | bytes[7]<<8 | bytes[8];//units:min
+    if(bytes.length==10 &&  0x07>bytes[0]< 0x0f)
+    return {
+      data: {
+        BAT_V:bat,
+        MOD:mod,
+        WATER_LEAK_STATUS:water_leak_status,
+        WATER_LEAK_TIMES:leak_times,
+        LAST_WATER_LEAK_DURATION:leak_duration
+      }
+    };
+  }
+  else if(mod==3)
+  if(bytes.length==10 &&  0x07>bytes[0]< 0x0f)
+  {
+    return {
+      data: {
+          BAT_V:bat,
+          MOD:mod,
+          DOOR_OPEN_STATUS:door_open_status,
+          WATER_LEAK_STATUS:water_leak_status,
+          ALARM:alarm
+        }
+    };
+  }
+  else{
+  return {
+    data: {
+        BAT_V:bat,
+        MOD:mod,
+      }
+  };
+  }
+}

--- a/transform_binary_payload/src-payload-decoders/python/dragino_lsn50v2.py
+++ b/transform_binary_payload/src-payload-decoders/python/dragino_lsn50v2.py
@@ -1,0 +1,184 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+import base64
+
+
+def dict_from_payload(base64_input: str, fport: int = None):
+
+    bytes = base64.b64decode(base64_input)
+    mode=(bytes[6] & 0x7C)>>2
+    if(mode!=2)and(mode!=31):
+        {
+        BatV=(bytes[0]<<8 | bytes[1])/1000
+        TempC1= parseFloat(((bytes[2]<<24>>16 | bytes[3])/10).toFixed(2))
+        ADC_CH0V=(bytes[4]<<8 | bytes[5])/1000
+        Digital_IStatus=((bytes[6] & 0x02)==2) and "H" or "L"
+        if(mode!=6):
+            {
+            EXTI_Trigger=((bytes[6] & 0x01)==1) and "TRUE" or "FALSE"
+            Door_status=((bytes[6] & 0x80)==128) and "CLOSE" or "OPEN"
+        }
+    }
+    result = {
+        "Mode": mode, 
+        "TempC1": TempC1,
+        "battery": BatV,
+        "ADC_CH0V": ADC_CH0V,
+        "Digital_IStatus": Digital_IStatus
+        "EXTI_Trigger": EXTI_Trigger
+        "Door_status": Door_status
+    }
+
+    return result
+
+
+    if(mode=='0'):
+        {
+        Work_mode="IIC";
+        if((bytes[9]<<8 | bytes[10])===0):
+            {
+                Illum=(bytes[7]<<24>>16 | bytes[8]);
+        }
+        else:
+            {
+            TempC_SHT=parseFloat(((bytes[7]<<24>>16 | bytes[8])/10).toFixed(2));
+            Hum_SHT=parseFloat(((bytes[9]<<8 | bytes[10])/10).toFixed(1));
+        }
+        result = {
+            "Work_mode": Work_mode,
+            "Illum": Illum,
+            "TempC_SHT": TempC_SHT
+            "Hum_SHT": Hum_SHT
+        }
+
+        return result
+    }
+    elif(mode=='1'):
+        {
+        Work_mode=" Distance";
+        Distance_cm=parseFloat(((bytes[7]<<8 | bytes[8])/10) .toFixed(1));
+        if((bytes[9]<<8 | bytes[10])!=65535):
+            {
+                Distance_signal_strength=parseFloat((bytes[9]<<8 | bytes[10]) .toFixed(0));
+        }
+    }
+    result = {
+        "Work_mode": Work_mode,
+        "Distance_cm": Distance_cm,
+        "Distance_signal_strength": Distance_signal_strength
+    }
+
+    return result
+
+    elif(mode=='2'):
+        {
+        Work_mode=" 3ADC";
+        BatV=bytes[11]/10;
+        ADC_CH0V=(bytes[0]<<8 | bytes[1])/1000;
+        ADC_CH1V=(bytes[2]<<8 | bytes[3])/1000;
+        ADC_CH4V=(bytes[4]<<8 | bytes[5])/1000;
+        Digital_IStatus=((bytes[6] & 0x02)==2) and "H" or "L"
+        EXTI_Trigger=((bytes[6] & 0x01)==1) and "TRUE" or "FALSE"
+        Door_status=((bytes[6] & 0x80)==128) and "CLOSE" or "OPEN"
+        if((bytes[9]<<8 | bytes[10])===0):
+            {
+                Illum=(bytes[7]<<24>>16 | bytes[8]);
+        }
+        else:
+            {
+            TempC_SHT=parseFloat(((bytes[7]<<24>>16 | bytes[8])/10).toFixed(2));
+            Hum_SHT=parseFloat(((bytes[9]<<8 | bytes[10])/10) .toFixed(1));
+        }
+    }
+    result = {
+        "Mode": mode,
+        "Work_mode": Work_mode,
+        "battery": BatV,
+        "ADC_CH0V": ADC_CH0V,
+        "ADC_CH1V": ADC_CH1V,
+        "ADC_CH4V": ADC_CH4V,
+        "Digital_IStatus": Digital_IStatus
+        "EXTI_Trigger": EXTI_Trigger
+        "Door_status": Door_status
+        "Illum": Illum,
+        "TempC_SHT": TempC_SHT
+        "Hum_SHT": Hum_SHT
+    }
+
+    return result
+
+    elif(mode=='3'):
+        {
+        Work_mode="3DS18B20";
+        TempC2=parseFloat(((bytes[7]<<24>>16 | bytes[8])/10).toFixed(2));
+        TempC3=parseFloat(((bytes[9]<<8 | bytes[10])/10) .toFixed(1));
+    }
+    result = {
+        "Work_mode": Work_mode,
+        "TempC2": TempC1,
+        "TempC3": TempC1,
+    }
+    return result
+
+    elif(mode=='4'):
+        {
+        Work_mode="Weight";
+        Weight=(bytes[7]<<24>>16 | bytes[8]);
+    }
+    result = {
+        "Work_mode": Work_mode,
+        "Weight": Weight,
+    }
+    return result
+
+    elif(mode=='5'):
+        {
+        Work_mode="Count";
+        Count=(bytes[7]<<24 | bytes[8]<<16 | bytes[9]<<8 | bytes[10]);
+    }
+    result = {
+        "Work_mode": Work_mode,
+        "Count": Count,
+    }
+    return result
+
+    elif(mode=='31'):
+        { 
+        Work_mode="ALARM";
+        BatV=(bytes[0]<<8 | bytes[1])/1000;
+        TempC1= parseFloat(((bytes[2]<<24>>16 | bytes[3])/10).toFixed(2));
+        TempC1MIN= bytes[4]<<24>>24;
+        TempC1MAX= bytes[5]<<24>>24; 
+        SHTEMPMIN= bytes[7]<<24>>24;
+        SHTEMPMAX= bytes[8]<<24>>24;   
+        SHTHUMMIN= bytes[9];
+        SHTHUMMAX= bytes[10];   
+    }
+    result = {
+        "Mode": mode,
+        "Work_mode": Work_mode,
+        "TempC1": TempC1,
+        "battery": BatV,
+        "TempC1MIN": TempC1MIN,
+        "TempC1MAX": TempC1MAX,
+        "SHTEMPMIN": SHTEMPMIN,
+        "SHTEMPMAX": SHTEMPMAX,
+        "SHTHUMMIN": SHTHUMMIN,
+        "SHTHUMMAX": SHTHUMMAX,
+    }
+    return result


### PR DESCRIPTION
Howdy! I have added payload decoders for several additional Dragino devices and updated readme file with the respective file names and the usable sample payload as well. All these decoders have been working in production for one of our client via AWS IOT Core for the respective LoRaWAN devices.

Dragino device decoders that have been added: 
LSPH01
LDDS20
LWL02
LSN50v2-D23

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
